### PR TITLE
Scaling with volumes instead of instance count and improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine
 
-RUN apk add --no-cache bash curl aws-cli postgresql-client && \
+RUN apk add --no-cache bash curl jq aws-cli postgresql-client && \
     curl -L https://fly.io/install.sh | sh
+
+ENV PATH="/root/.fly/bin:$PATH"
 
 COPY ./pg-dump-to-s3.sh ./entrypoint.sh /
 

--- a/create-resources-utils/create-aws-resources.sh
+++ b/create-resources-utils/create-aws-resources.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+BACKUP_RETENTION_DAYS=${BACKUP_RETENTION_DAYS:-60}
+
+
 read -p 'Name (ex: puzzle, bion, activeflow...): ' name
 read -p 'Aws region to create the bucket (ex: eu-central-1, eu-west-3): ' region
 
@@ -27,12 +30,12 @@ bucket_lifecycle_configuration="
 {
   \"Rules\": [
       {
-          \"ID\": \"Delete database backups after 30 days\",
+          \"ID\": \"Delete database backups after $BACKUP_RETENTION_DAYS days\",
           \"Filter\": {},
           \"Status\": \"Enabled\",
           \"NoncurrentVersionExpiration\": {
-              \"NoncurrentDays\": 30,
-              \"NewerNoncurrentVersions\": 30
+              \"NoncurrentDays\": $BACKUP_RETENTION_DAYS,
+              \"NewerNoncurrentVersions\": $BACKUP_RETENTION_DAYS
           }
       }
   ]

--- a/create-resources-utils/create-fly-resources.sh
+++ b/create-resources-utils/create-fly-resources.sh
@@ -4,10 +4,10 @@ set -e
 
 VOLUME_SIZE_IN_GB="3"
 
-read -p 'Name (ex: puzzle, bion, activeflow...): ' name
+read -p 'Name prefix (PREFIX-db-backup-worker):' name_prefix
 read -p 'Fly organization name: ' fly_organization_name
 
-app_name="${name}-db-backup-worker"
+app_name="${name_prefix}-db-backup-worker"
 
 echo "Creating ${app_name} app on fly"
 fly apps create --name "${app_name}" --org "${fly_organization_name}"

--- a/create-resources-utils/fly.toml
+++ b/create-resources-utils/fly.toml
@@ -1,6 +1,9 @@
 kill_signal = "SIGINT"
 kill_timeout = 10
 
+[experimental]
+  auto_rollback = false
+
 [build]
   image = "ghcr.io/significa/fly-pg-dump-to-s3"
 

--- a/create-resources-utils/grant-db-permissions.sh
+++ b/create-resources-utils/grant-db-permissions.sh
@@ -3,7 +3,6 @@
 set -e
 
 DB_PASSWORD_SIZE=32
-ENV_FILE=.env
 
 read -p 'Fly database app: ' database_app
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 BACKUP_CONFIGURATION_NAMES=${BACKUP_CONFIGURATION_NAMES:-}
 
-backup () {
+backup_database () {
   local prefix=$1
 
   database_url_var_name="${prefix}DATABASE_URL"
@@ -18,27 +18,32 @@ backup () {
     exit 1
   fi
 
-  ./pg-dump-to-s3.sh "${database_url}" "${s3_destination}"
+  ./pg-dump-to-s3.sh "$database_url" "$s3_destination"
 }
 
-main () {
+backup_databases () {
   if [[ -z $BACKUP_CONFIGURATION_NAMES ]]; then
       echo "Backup starting"
-      backup ""
+      backup_database ""
   else
     for configuration_name in ${BACKUP_CONFIGURATION_NAMES//,/ }; do
       echo "Backing up $configuration_name"
-      backup "${configuration_name^^}_"
+      backup_database "${configuration_name^^}_"
     done
   fi
 }
 
-main || echo "ERROR backing up, see the logs above."
+backup_databases || echo "ERROR backing up, see the logs above."
 
 if [[ -n $FLY_APP_NAME && -n $FLY_API_TOKEN ]]; then
-  echo "Scaling $FLY_APP_NAME to 0"
-  /root/.fly/bin/flyctl -a "$FLY_APP_NAME" scale count 0
+  volume_id=$(fly volumes list -a "$FLY_APP_NAME" --json | jq -r '.[0] | .id')
+
+  echo "Deleting volume $volume_id"
+  set -x
+  fly volumes delete "$volume_id" --yes
+
+  echo "Done! Sleeping..."
+  sleep infinity
 fi
 
-echo "Done! Sleeping..."
-sleep infinity
+echo "Done!"


### PR DESCRIPTION
This PR changes how this app is deployed. Please refer to the new readme.

To upgrade one should:
 - update the image tag
 - scale the app to  1: `fly scale count 1`
 - change the backup command to `fly volumes create --no-encryption --size $VOLUME_SIZE_IN_GB --region $REGION temp_data`