### PR TITLE
Fix: typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Have a look into [create-resources-utils](./create-resources-utils) for scripts 
     AWS_ACCESS_KEY_ID=XXXX
     AWS_SECRET_ACCESS_KEY=XXXX
     DATABASE_URL=postgresql://username:password@my-fly-db-instance.internal:5432/my_database
-    S3_DESTINATON=s3://your-s3-bucket/backup.tar.gz
+    S3_DESTINATION=s3://your-s3-bucket/backup.tar.gz
     FLY_API_TOKEN=XXXX
     ```
 
@@ -82,7 +82,7 @@ Have a look into [create-resources-utils](./create-resources-utils) for scripts 
 
 ## What about backup history?
 
-You could add a date to the S3_DESTINATON filename (by changing the docker CMD). But I recommend adding versioning to your S3 and manage retention via policies.
+You could add a date to the S3_DESTINATION filename (by changing the docker CMD). But I recommend adding versioning to your S3 and manage retention via policies.
 
 
 ## Backup multiple databases/backups in one go?
@@ -93,13 +93,13 @@ Just use the env vars like so:
 BACKUP_CONFIGURATION_NAMES=ENV1,STAGING_ENVIRONMENT,test
 
 ENV1_DATABASE_URL=postgresql://username:password@env1/my_database
-ENV1_S3_DESTINATON=s3://sample-bucket/sample.tar.gz
+ENV1_S3_DESTINATION=s3://sample-bucket/sample.tar.gz
 
 STAGING_ENVIRONMENT_DATABASE_URL=postgresql://username:password@sample/staging
-STAGING_ENVIRONMENT_S3_DESTINATON=s3://sample-db-backups/staging_backup.tar.gz
+STAGING_ENVIRONMENT_S3_DESTINATION=s3://sample-db-backups/staging_backup.tar.gz
 
 TEST_DATABASE_URL=postgresql://username:password@sample/test
-TEST_S3_DESTINATON=s3://sample-db-backups/test_backup.tar.gz
+TEST_S3_DESTINATION=s3://sample-db-backups/test_backup.tar.gz
 ```
 
 It will backup all the databases to the desired s3 destination. AWS and fly tokens are reused.
@@ -108,8 +108,8 @@ It will backup all the databases to the desired s3 destination. AWS and fly toke
 ## Env vars documentation
 
 - `DATABASE_URL`: Postgres database URL. Example: `postgresql://username:password@test:5432/my_database`
-- `S3_DESTINATON`: AWS S3 fill file destination Postgres database URl
-- `BACKUP_CONFIGURATION_NAMES`: Optional: Configuration names/prefixes for `DATABASE_URL` and `S3_DESTINATON`
+- `S3_DESTINATION`: AWS S3 fill file destination Postgres database URl
+- `BACKUP_CONFIGURATION_NAMES`: Optional: Configuration names/prefixes for `DATABASE_URL` and `S3_DESTINATION`
 - `FLY_APP_NAME`:  Optional to delete the volume and terminate the worker. Automatically set by Fly.
 - `FLY_API_TOKEN`: Optional to delete the volume and terminate the worker. Fly API token created via `flyctl` or the web UI.
 - `BACKUPS_TEMP_DIR`: Optional: Where the temp files should go. Defaults to: `/tmp/db-backups`

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Fly pg_dump to AWS S3
 
 This is a **hacky** way to have a Fly app that dumps postgres databases that are also on Fly, to AWS S3 buckets.
-This uses a dedicaded app for the *backup worker* that is woken up to start the dump. When it finished it is scaled back to 0, meaning it is not billable when idle.
+This uses a dedicated app for the *backup worker* that is woken up to start the dump. When it finished it is scaled back to 0, meaning it is not billable when idle.
 
 
 ## Why this?
 
 Indeed Fly's pg images support wal-g config to S3 via env vars. But I wanted a way to create simple archives periodically with pg_dump, making it easy for developers to replicate databases, and have a point in time recovery.
 
-Since the backup worker is running on Fly, and not in some other external service like AWS or GitHub actions, we can create backups rather quickly. And also because the latency/bandwith from Fly to AWS are quite good (in the regions I've tested).
+Since the backup worker is running on Fly, and not in some other external service like AWS or GitHub actions, we can create backups rather quickly. And also because the latency/bandwidth from Fly to AWS are quite good (in the regions I've tested).
 
 And what about Fly machines? I haven't tried them.
 
@@ -17,7 +17,7 @@ And what about Fly machines? I haven't tried them.
 
 Have a look into [create-resources-utils](./create-resources-utils) for scripts to setup all the requirements in a simple way.
 
-1. Fly postgres instance and a user with read permissons.
+1. Fly postgres instance and a user with read permissions.
    Create the `db_backup_worker` user with:
     ```sql
     CREATE USER db_backup_worker WITH PASSWORD '<password>';
@@ -74,7 +74,7 @@ Have a look into [create-resources-utils](./create-resources-utils) for scripts 
     ```
 
 4. Run `fly volumes create --no-encryption --size $SIZE_IN_GB --region $REGION temp_data` whenever you want to start a backup.
-   `SIZE_IN_GB` is the size of the temporary disk where the ephermal files live during the backuo, set it accordingly to the size of the db.
+   `SIZE_IN_GB` is the size of the temporary disk where the ephemeral files live during the backup, set it accordingly to the size of the db.
    `REGION` is the region of the volume and consequently the region where the worker will run. Choose one close to the db and the AWS bucket region.
    The volume will be deleted when the backup finishes.
    Add this command to any periodic runner along with the envs `FLY_APP` and `FLY_API_TOKEN` to perform backups periodically. 
@@ -108,11 +108,11 @@ It will backup all the databases to the desired s3 destination. AWS and fly toke
 ## Env vars documentation
 
 - `DATABASE_URL`: Postgres database URL. Example: `postgresql://username:password@test:5432/my_database`
-- `S3_DESTINATON`: AWS S3 fill file destinaton Postgres database URl
-- `BACKUP_CONFIGURATION_NAMES`: Optional: Configuration names/prefixs for `DATABASE_URL` and `S3_DESTINATON`
+- `S3_DESTINATON`: AWS S3 fill file destination Postgres database URl
+- `BACKUP_CONFIGURATION_NAMES`: Optional: Configuration names/prefixes for `DATABASE_URL` and `S3_DESTINATON`
 - `FLY_APP_NAME`:  Optional to delete the volume and terminate the worker. Automatically set by Fly.
 - `FLY_API_TOKEN`: Optional to delete the volume and terminate the worker. Fly API token created via `flyctl` or the web UI.
-- `BACKUPS_TEMP_DIR`: Optional: Where the temp files shoudl go. Defaults to: `/tmp/db-backups`
+- `BACKUPS_TEMP_DIR`: Optional: Where the temp files should go. Defaults to: `/tmp/db-backups`
 - `PG_DUMP_ARGS`: Optional: Override the default `pg_dump` args: `--no-owner --clean --no-privileges --no-sync --jobs=4 --format=directory --compress=0`
 
 
@@ -123,4 +123,4 @@ Yes. Yes :sweat_smile:
 
 ## Will this work outside fly?
 
-Yes, if FLY_APP_NAME or FLY_API_TOKEN are not prsent, fly commands will be ignored.
+Yes, if FLY_APP_NAME or FLY_API_TOKEN are not present, fly commands will be ignored.

--- a/create-resources-utils/README.md
+++ b/create-resources-utils/README.md
@@ -21,8 +21,8 @@ AWS_ACCESS_KEY_ID=aws_access_key_id
 AWS_SECRET_ACCESS_KEY=aws_secret_access_key
 
 BACKUP_CONFIGURATION_NAMES=STAGING,PRODUCTION
-STAGING_S3_DESTINATON=s3://example-bucket/project-name-db-backup-staging.tar.gz
-PRODUCTION_S3_DESTINATON=s3://example-bucket/project-name-db-backup-production.tar.gz
+STAGING_S3_DESTINATION=s3://example-bucket/project-name-db-backup-staging.tar.gz
+PRODUCTION_S3_DESTINATION=s3://example-bucket/project-name-db-backup-production.tar.gz
 ```
 
 ## Create database user and grant permissions

--- a/create-resources-utils/create-aws-resources.sh
+++ b/create-resources-utils/create-aws-resources.sh
@@ -89,5 +89,5 @@ aws_secret_access_key=$(echo "${create_access_key_response}" | jq -r '.AccessKey
 echo "AWS_ACCESS_KEY_ID=${aws_access_key_id}"
 echo "AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}"
 echo "BACKUP_CONFIGURATION_NAMES=STAGING,PRODUCTION"
-echo "STAGING_S3_DESTINATON=s3://${bucket_name}/${name}-db-backup-staging.tar.gz"
-echo "PRODUCTION_S3_DESTINATON=s3://${bucket_name}/${name}-db-backup-production.tar.gz"
+echo "STAGING_S3_DESTINATION=s3://${bucket_name}/${name}-db-backup-staging.tar.gz"
+echo "PRODUCTION_S3_DESTINATION=s3://${bucket_name}/${name}-db-backup-production.tar.gz"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ backup_database () {
   database_url_var_name="${prefix}DATABASE_URL"
   database_url=${!database_url_var_name}
 
-  s3_destination_var_name="${prefix}S3_DESTINATON"
+  s3_destination_var_name="${prefix}S3_DESTINATION"
   s3_destination=${!s3_destination_var_name}
 
   if [[ -z $database_url || -z $s3_destination ]]; then


### PR DESCRIPTION
This is a breaking change because we were using the `S3_DESTINATION` env var with a typo:
```diff
-  <prefix>S3_DESTINATON
+  <prefix>S3_DESTINATION
```

