### PR TITLE
Allow passing ensure-no-volumes-left from workflow and documentation improvements

### DIFF
--- a/.github/workflows/trigger-backup.yaml
+++ b/.github/workflows/trigger-backup.yaml
@@ -4,29 +4,34 @@ on:
   workflow_call:
     inputs:
       fly-app:
-        description: 'The Fly app name of your db backup worker.'
+        description: The Fly app name of your db backup worker.
         required: true
         type: string
       volume-size:
-        description: 'The volume size in GB for the volume of the backup worker.'
+        description: The volume size in GB for the volume of the backup worker.
         required: false
         type: number
       machine-size:
-        description: 'Fly machines v2 size (https://fly.io/docs/about/pricing/#machines)'
+        description: Fly machines v2 size (https://fly.io/docs/about/pricing/#machines)
         required: false
         type: string
       region:
-        description: 'The region to run the backup worker from.'
+        description: The region to run the backup worker from.
         required: false
         type: string
       timeout:
-        description: 'Backup GitHub action step timeout, in minutes.'
+        description: Backup GitHub action step timeout, in minutes.
         required: false
         type: number
       docker-image:
-        description: 'The image of the backup worker. Usefull to override with specific versions.'
+        description: The image of the backup worker. Usefull to override with specific versions.
         required: false
         type: string
+      ensure-no-volumes-left:
+        description: >-
+          Makes the action crash if when the backup finishes there are still volumes in the app
+        required: false
+        type: boolean
 
     secrets:
       FLY_API_TOKEN:
@@ -55,3 +60,4 @@ jobs:
           FLY_MACHINE_SIZE: ${{ inputs.machine-size }}
           FLY_VOLUME_SIZE: ${{ inputs.volume-size }}
           DOCKER_IMAGE: ${{ inputs.docker-image }}
+          ENSURE_NO_VOLUMES_LEFT: ${{ inputs.ensure-no-volumes-left }}

--- a/trigger-backup.sh
+++ b/trigger-backup.sh
@@ -11,7 +11,7 @@ FLY_MACHINE_SIZE=${FLY_MACHINE_SIZE:-shared-cpu-4x}
 FLY_VOLUME_SIZE=${FLY_VOLUME_SIZE:-3}
 DEFAULT_DOCKER_IMAGE="ghcr.io/significa/fly-pg-dump-to-s3:3"
 DOCKER_IMAGE=${DOCKER_IMAGE:-$DEFAULT_DOCKER_IMAGE}
-ENSURE_NO_VOLUMES_LEFT=${ENSURE_NO_VOLUMES_LEFT-true}
+ENSURE_NO_VOLUMES_LEFT=${ENSURE_NO_VOLUMES_LEFT-false}
 
 if [[ -z "$FLY_APP" || -z "$FLY_API_TOKEN" ]]; then
   >&2 echo "Env vars FLY_APP and FLY_API_TOKEN must not be empty"
@@ -50,7 +50,7 @@ flyctl machines run \
 sleep "$SLEEP_TIME_SECONDS"
 
 echo "Waiting for volume to become detached."
-until flyctl volumes show "$volume_id" --json | jq -er '.AttachedMachine == null'; do
+until flyctl volumes show "$volume_id" --json | jq -er '.AttachedMachine == null' > /dev/null; do
   printf "."
   sleep 5
 done
@@ -60,9 +60,17 @@ sleep "$SLEEP_TIME_SECONDS"
 echo "Deleting volume $volume_id"
 flyctl volumes delete --yes "$volume_id" 
 
-if "$ENSURE_NO_VOLUMES_LEFT" && fly volumes list --app="$FLY_APP" --json | jq -e 'length != 0' ; then
-  >&2 echo "Backup completed but the app still has volumes. ENSURE_NO_VOLUMES_LEFT is true, exiting"
-  exit 1
+sleep "$SLEEP_TIME_SECONDS"
+
+volumes_left=$(fly volumes list --app="$FLY_APP" --json)
+
+if jq -e 'length != 0' <<< "$volumes_left" > /dev/null ; then
+  >&2 echo -e "WARNING: Backup completed but the app still has volumes. Response:\n$volumes_left"
+
+  if "$ENSURE_NO_VOLUMES_LEFT" ; then
+    >&2 echo "ERROR: ENSURE_NO_VOLUMES_LEFT is true, exiting."
+    exit 1
+  fi
 fi
 
 echo "Done"


### PR DESCRIPTION
Now that we have deployed this v3, looks like Fly does not behave properly every time.

- Changed the `ENSURE_NO_VOLUMES_LEFT` default to `false` .
- Added more sleep time to make sure fly has time to figure out its state.
- Added `ensure-no-volumes-left` to the reusable workflows.
- Improved the documentation and error/warning messages.