### PR TITLE
Update base image tag and deprecate linux/386 target platform

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           context: ./
           file: ./Dockerfile
-          platforms: linux/amd64, linux/arm64, linux/386
+          platforms: linux/amd64, linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM alpine
+# https://hub.docker.com/_/alpine/tags
+ARG IMAGE_TAG=3.18
+
+FROM alpine:$IMAGE_TAG
 
 RUN apk update && \
     apk add --no-cache bash curl aws-cli postgresql-client && \


### PR DESCRIPTION
AWS cli is not available for linux/386 architecture and we do not need to maintain it